### PR TITLE
fix: Increase minimal chrono version to avoid RUSTSEC-2020-0159 vulnerability

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ version = "0.1.0"
 exclude = [".github/**", ".vscode/**", "TODO.md", "Cargo.lock", "target/**", ".gitignore", "mutants.*/**"]
 
 [dependencies]
-chrono = { version = "0.4", default-features = false, features = ["std", "now"] }
+chrono = { version = "0.4.20", default-features = false, features = ["std", "now"] }
 
 [dev-dependencies]
 rstest = { version = "0.23.0", default-features = false }

--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ fn main() -> Result<()> {
 - [ ] More unit tests for edge cases.
 - [ ] Aliases: `@yearly`, `@annually`, `@monthly`, `@daily`, `@midnight`, `@hourly`.
 - [ ] Feature `tz`: timezone-aware schedule pattern.
+- [ ] Feature `serde`: implement Serialize/Deserialize traits for `Schedule`.
 
 ## License
 


### PR DESCRIPTION
https://rustsec.org/advisories/RUSTSEC-2020-0159.html