### PR TITLE
feat!: Implement tz feature

### DIFF
--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -1,3 +1,4 @@
 # output = "target"
 additional_cargo_args = ["--all-features"]
 cap_lints = true
+exclude_re = ["src/schedule.rs:124:9: replace Schedule::upcoming -> Option<DateTime<T>> with .*"]

--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -1,4 +1,4 @@
 # output = "target"
 additional_cargo_args = ["--all-features"]
 cap_lints = true
-exclude_re = ["src/schedule.rs:124:9: replace Schedule::upcoming -> Option<DateTime<T>> with .*"]
+exclude_re = ["src/schedule.rs:123:9: replace Schedule::upcoming -> Option<DateTime<T>> with .*"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ keywords = ["time", "cron", "schedule", "repeat", "periodic"]
 license = "MIT"
 readme = "README.md"
 repository = "https://github.com/alex-karpenko/cron-lite"
-version = "0.1.0"
+version = "0.2.0"
 exclude = [".github/**", ".vscode/**", "TODO.md", "Cargo.lock", "target/**", ".gitignore", "mutants.*/**"]
 
 [features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,9 +16,11 @@ exclude = [".github/**", ".vscode/**", "TODO.md", "Cargo.lock", "target/**", ".g
 [features]
 default = []
 serde = ["dep:serde"]
+tz = ["dep:chrono-tz"]
 
 [dependencies]
 chrono = { version = "0.4.20", default-features = false }
+chrono-tz = { version = "0.10.0", default-features = false, optional = true }
 serde = { version = "1.0", default-features = false, features = ["derive", "std"], optional = true }
 
 [dev-dependencies]

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ This crate uses such a format by default, but two optional fields may be added, 
 The table below describes valid values and patterns of each field:
 
 | Field        | Required | Allowed values  | Allowed special characters |
-| ------------ | -------- | --------------- | -------------------------- |
+|--------------|----------|-----------------|----------------------------|
 | Seconds      | No       | 0-59            | * , - /                    |
 | Minutes      | Yes      | 0-59            | * , - /                    |
 | Hours        | Yes      | 0-23            | * , - /                    |
@@ -59,7 +59,7 @@ Patterns meanings:
 Also, short aliases for well-known schedule expressions are allowed:
 
 | Alias                      | Expression    |
-| -------------------------- | ------------- |
+|----------------------------|---------------|
 | `@yearly` (or `@annually`) | 0 0 0 1 1 ? * |
 | `@monthly`                 | 0 0 0 1 * ? * |
 | `@weekly`                  | 0 0 0 ? * 0 * |
@@ -68,6 +68,13 @@ Also, short aliases for well-known schedule expressions are allowed:
 
 Some additional information and fields description and relationships may be
 found [here](https://en.wikipedia.org/wiki/Cron#Cron_expression) (this is not complete or exceptional documentation).
+
+### Schedule with timezone
+
+If `tz` feature is enabled, it's possible to prefix cron schedule with timezone, for example:
+
+- `TZ=Europe/Paris @monthly`
+- `TZ=EET 0 12 * * *`
 
 ## How to use
 
@@ -112,13 +119,19 @@ fn main() -> Result<()> {
 }
 ```
 
+## Feature flags
+
+* `serde`: adds [`Serialize`](https://docs.rs/serde/latest/serde/trait.Serialize.html) and [
+  `Deserialize`](https://docs.rs/serde/latest/serde/trait.Deserialize.html) trait implementation for [`Schedule`].
+* `tz`: enables support of cron [schedules with timezone](#schedule-with-timezone).
+
 ## TODO
 
 - [ ] Descriptive example.
 - [x] Performance tests.
 - [ ] More unit tests for edge cases.
 - [x] Aliases: `@yearly`, `@annually`, `@monthly`, `@daily`, `@midnight`, `@hourly`.
-- [ ] Feature `tz`: timezone-aware schedule pattern.
+- [x] Feature `tz`: timezone-aware schedule pattern.
 - [x] Feature `serde`: implement Serialize/Deserialize traits for `Schedule`.
 
 ## License

--- a/benches/schedule.rs
+++ b/benches/schedule.rs
@@ -12,9 +12,11 @@ const EXPRESSIONS: &[&str] = &[
     "0 * * * JAN-DEC *",
 ];
 
-const TIME_ZONES: &[&str] = &["UTC", "EET", "Europe/Kyiv"];
 const NOW: &[&str] = &["1999-12-31T23:59:59Z", "2000-01-01T00:00:00Z", "2099-12-31T23:59:59Z"];
 const TAKE_SAMPLES: usize = 10_000;
+
+#[cfg(feature = "tz")]
+const TIME_ZONES: &[&str] = &["UTC", "EET", "Europe/Kyiv"];
 
 pub fn new_benchmark(c: &mut Criterion) {
     let mut group = c.benchmark_group("new");
@@ -26,11 +28,9 @@ pub fn new_benchmark(c: &mut Criterion) {
         #[cfg(feature = "tz")]
         for tz in TIME_ZONES {
             let expression = format!("TZ={tz} {expression}");
-            group.bench_with_input(
-                BenchmarkId::from_parameter(format!("{expression}")),
-                &expression,
-                |b, e| b.iter(|| Schedule::new(e).unwrap()),
-            );
+            group.bench_with_input(BenchmarkId::from_parameter(expression.clone()), &expression, |b, e| {
+                b.iter(|| Schedule::new(e).unwrap())
+            });
         }
     }
     group.finish();

--- a/src/error.rs
+++ b/src/error.rs
@@ -20,7 +20,6 @@ pub enum CronError {
     /// Invalid repeating pattern.
     InvalidRepeatingPattern(String, String),
     /// Invalid TimeZone
-    #[cfg(feature = "tz")]
     InvalidTimeZone(String),
 }
 
@@ -43,7 +42,6 @@ impl Display for CronError {
             CronError::InvalidRepeatingPattern(pattern, type_) => {
                 write!(f, "{type_}: invalid repeating pattern: {}", pattern)
             }
-            #[cfg(feature = "tz")]
             CronError::InvalidTimeZone(tz) => write!(f, "invalid time zone: {}", tz),
         }
     }
@@ -101,7 +99,6 @@ mod tests {
         assert_eq!(error.to_string(), "minutes: invalid repeating pattern: */0");
     }
 
-    #[cfg(feature = "tz")]
     #[test]
     fn test_invalid_tz() {
         let error = CronError::InvalidTimeZone("qqq".to_string());

--- a/src/error.rs
+++ b/src/error.rs
@@ -19,6 +19,9 @@ pub enum CronError {
     InvalidRangeValue(String, String),
     /// Invalid repeating pattern.
     InvalidRepeatingPattern(String, String),
+    /// Invalid TimeZone
+    #[cfg(feature = "tz")]
+    InvalidTimeZone(String),
 }
 
 impl Error for CronError {}
@@ -40,6 +43,8 @@ impl Display for CronError {
             CronError::InvalidRepeatingPattern(pattern, type_) => {
                 write!(f, "{type_}: invalid repeating pattern: {}", pattern)
             }
+            #[cfg(feature = "tz")]
+            CronError::InvalidTimeZone(tz) => write!(f, "invalid time zone: {}", tz),
         }
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -100,4 +100,11 @@ mod tests {
         let error = CronError::InvalidRepeatingPattern("*/0".to_string(), "minutes".to_string());
         assert_eq!(error.to_string(), "minutes: invalid repeating pattern: */0");
     }
+
+    #[cfg(feature = "tz")]
+    #[test]
+    fn test_invalid_tz() {
+        let error = CronError::InvalidTimeZone("qqq".to_string());
+        assert_eq!(error.to_string(), "invalid time zone: qqq");
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,7 +56,7 @@
 //! ### Schedule with timezone
 //! If `tz` feature is enabled, it's possible to prefix cron schedule with timezone, for example:
 //! - `TZ=Europe/Paris @monthly`
-//! - `TZ=PST 0 12 * * *`
+//! - `TZ=EET 0 12 * * *`
 //!
 //! ## How to use
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,6 +53,11 @@
 //!
 //! Some additional information and fields description and relationships may be found [here](https://en.wikipedia.org/wiki/Cron#Cron_expression) (this is not complete or exceptional documentation).
 //!
+//! ### Schedule with timezone
+//! If `tz` feature is enabled, it's possible to prefix cron schedule with timezone, for example:
+//! - `TZ=Europe/Paris @monthly`
+//! - `TZ=PST 0 12 * * *`
+//!
 //! ## How to use
 //!
 //! The single public entity of the crate is a [`Schedule`] structure, which has three basic methods:
@@ -98,6 +103,7 @@
 //!
 //! # Feature flags
 //! * `serde`: adds [`Serialize`](https://docs.rs/serde/latest/serde/trait.Serialize.html) and [`Deserialize`](https://docs.rs/serde/latest/serde/trait.Deserialize.html) trait implementation for [`Schedule`].
+//! * `tz`: enables support of cron [schedules with timezone](#schedule-with-timezone).
 
 /// Crate specific Error implementation.
 pub mod error;

--- a/src/schedule.rs
+++ b/src/schedule.rs
@@ -21,7 +21,6 @@ pub(crate) const MIN_YEAR_STR: &str = "1970";
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(try_from = "String"))]
 #[cfg_attr(feature = "serde", serde(into = "String"))]
-#[cfg_attr(not(feature = "tz"), derive(PartialOrd, Ord))]
 pub struct Schedule {
     year: Pattern,
     month: Pattern,
@@ -31,7 +30,7 @@ pub struct Schedule {
     minute: Pattern,
     second: Pattern,
     #[cfg(feature = "tz")]
-    tz: Option<chrono_tz::Tz>,
+    tz: Option<Tz>,
 }
 
 impl Schedule {
@@ -117,7 +116,7 @@ impl Schedule {
     /// - calculates upcoming event time;
     /// - converts obtained upcoming value back to the timezone of the `current` instance.
     ///
-    /// Returns `None` if there is no time of the upcoming event.
+    /// Returns `None` if there is no time for the upcoming event.
     #[cfg(not(feature = "tz"))]
     #[inline]
     pub fn upcoming<T: TimeZone>(&self, current: &DateTime<T>) -> Option<DateTime<T>> {
@@ -277,7 +276,6 @@ impl Schedule {
 
 /// Contains iterator state.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
-#[cfg_attr(not(feature = "tz"), derive(PartialOrd, Ord))]
 struct ScheduleIterator<Tz: TimeZone> {
     schedule: Schedule,
     next: Option<DateTime<Tz>>,

--- a/src/schedule.rs
+++ b/src/schedule.rs
@@ -1188,8 +1188,7 @@ mod tests {
         #[case("TZ=Asia/Tokyo @yearly", "TZ=Asia/Tokyo 0 0 0 1 1 ? *")]
         #[case("Tz=Asia/Tokyo @yearly", "TZ=Asia/Tokyo 0 0 0 1 1 ? *")]
         #[case("tz=Asia/Tokyo @yearly", "TZ=Asia/Tokyo 0 0 0 1 1 ? *")]
-        #[case("tz=Europe/Paris @yearly", "TZ=Asia/Tokyo 0 0 0 1 1 ? *")]
-        #[case("tz=PST @yearly", "TZ=Asia/Tokyo 0 0 0 1 1 ? *")]
+        #[case("tz=Europe/Paris @yearly", "TZ=Europe/Paris 0 0 0 1 1 ? *")]
         fn valid_schedules_to_test(#[case] input: &str, #[case] expected: &str) {}
 
         #[apply(valid_schedules_to_test)]

--- a/src/schedule.rs
+++ b/src/schedule.rs
@@ -1268,5 +1268,270 @@ mod tests {
                 );
             }
         }
+
+        #[rstest]
+        #[timeout(Duration::from_secs(1))]
+        fn test_schedule_iter() {
+            let schedule = Schedule::new("TZ=UTC 0 0 12 * 1 MON 2024").unwrap();
+            let mut iter = schedule.iter(&DateTime::parse_from_rfc3339("2024-01-01T00:00:00+00:00").unwrap());
+
+            assert_eq!(
+                iter.next().unwrap().to_rfc3339(),
+                "2024-01-01T12:00:00+00:00",
+                "schedule = {schedule}"
+            );
+            assert_eq!(
+                iter.next().unwrap().to_rfc3339(),
+                "2024-01-08T12:00:00+00:00",
+                "schedule = {schedule}"
+            );
+            assert_eq!(
+                iter.next().unwrap().to_rfc3339(),
+                "2024-01-15T12:00:00+00:00",
+                "schedule = {schedule}"
+            );
+            assert_eq!(
+                iter.next().unwrap().to_rfc3339(),
+                "2024-01-22T12:00:00+00:00",
+                "schedule = {schedule}"
+            );
+            assert_eq!(
+                iter.next().unwrap().to_rfc3339(),
+                "2024-01-29T12:00:00+00:00",
+                "schedule = {schedule}"
+            );
+            assert_eq!(iter.next(), None);
+        }
+
+        #[rstest]
+        #[timeout(Duration::from_secs(1))]
+        fn test_schedule_iter_every_second() {
+            let schedule = Schedule::new("TZ=EET * * * * * *").unwrap();
+            let mut iter = schedule.iter(&DateTime::parse_from_rfc3339("2024-01-01T00:00:01+00:00").unwrap());
+
+            assert_eq!(
+                iter.next().unwrap().to_rfc3339(),
+                "2024-01-01T00:00:01+00:00",
+                "schedule = {schedule}"
+            );
+            assert_eq!(
+                iter.next().unwrap().to_rfc3339(),
+                "2024-01-01T00:00:02+00:00",
+                "schedule = {schedule}"
+            );
+            assert_eq!(
+                iter.next().unwrap().to_rfc3339(),
+                "2024-01-01T00:00:03+00:00",
+                "schedule = {schedule}"
+            );
+            assert_eq!(
+                iter.next().unwrap().to_rfc3339(),
+                "2024-01-01T00:00:04+00:00",
+                "schedule = {schedule}"
+            );
+            assert_eq!(
+                iter.next().unwrap().to_rfc3339(),
+                "2024-01-01T00:00:05+00:00",
+                "schedule = {schedule}"
+            );
+        }
+
+        #[rstest]
+        #[timeout(Duration::from_secs(1))]
+        fn test_schedule_iter_every_minute() {
+            let schedule = Schedule::new("TZ=Europe/Kyiv * * * * *").unwrap();
+            let mut iter = schedule.iter(&DateTime::parse_from_rfc3339("2024-01-01T00:00:01+00:00").unwrap());
+
+            assert_eq!(
+                iter.next().unwrap().to_rfc3339(),
+                "2024-01-01T00:01:00+00:00",
+                "schedule = {schedule}"
+            );
+            assert_eq!(
+                iter.next().unwrap().to_rfc3339(),
+                "2024-01-01T00:02:00+00:00",
+                "schedule = {schedule}"
+            );
+            assert_eq!(
+                iter.next().unwrap().to_rfc3339(),
+                "2024-01-01T00:03:00+00:00",
+                "schedule = {schedule}"
+            );
+            assert_eq!(
+                iter.next().unwrap().to_rfc3339(),
+                "2024-01-01T00:04:00+00:00",
+                "schedule = {schedule}"
+            );
+            assert_eq!(
+                iter.next().unwrap().to_rfc3339(),
+                "2024-01-01T00:05:00+00:00",
+                "schedule = {schedule}"
+            );
+        }
+
+        #[rstest]
+        #[timeout(Duration::from_secs(1))]
+        fn test_schedule_iter_every_hour() {
+            let schedule = Schedule::new("TZ=Canada/Eastern 13 * * * *").unwrap();
+            let mut iter = schedule.iter(&DateTime::parse_from_rfc3339("2024-01-01T07:01:01+00:00").unwrap());
+
+            assert_eq!(
+                iter.next().unwrap().to_rfc3339(),
+                "2024-01-01T07:13:00+00:00",
+                "schedule = {schedule}"
+            );
+            assert_eq!(
+                iter.next().unwrap().to_rfc3339(),
+                "2024-01-01T08:13:00+00:00",
+                "schedule = {schedule}"
+            );
+            assert_eq!(
+                iter.next().unwrap().to_rfc3339(),
+                "2024-01-01T09:13:00+00:00",
+                "schedule = {schedule}"
+            );
+            assert_eq!(
+                iter.next().unwrap().to_rfc3339(),
+                "2024-01-01T10:13:00+00:00",
+                "schedule = {schedule}"
+            );
+            assert_eq!(
+                iter.next().unwrap().to_rfc3339(),
+                "2024-01-01T11:13:00+00:00",
+                "schedule = {schedule}"
+            );
+        }
+
+        #[rstest]
+        #[timeout(Duration::from_secs(1))]
+        fn test_schedule_iter_every_day() {
+            let schedule = Schedule::new("TZ=Asia/Tokyo 22 5 * * *").unwrap();
+            let mut iter = schedule.iter(&DateTime::parse_from_rfc3339("2024-01-01T04:01:01+00:00").unwrap());
+
+            assert_eq!(
+                iter.next().unwrap().to_rfc3339(),
+                "2024-01-01T20:22:00+00:00",
+                "schedule = {schedule}"
+            );
+            assert_eq!(
+                iter.next().unwrap().to_rfc3339(),
+                "2024-01-02T20:22:00+00:00",
+                "schedule = {schedule}"
+            );
+            assert_eq!(
+                iter.next().unwrap().to_rfc3339(),
+                "2024-01-03T20:22:00+00:00",
+                "schedule = {schedule}"
+            );
+            assert_eq!(
+                iter.next().unwrap().to_rfc3339(),
+                "2024-01-04T20:22:00+00:00",
+                "schedule = {schedule}"
+            );
+            assert_eq!(
+                iter.next().unwrap().to_rfc3339(),
+                "2024-01-05T20:22:00+00:00",
+                "schedule = {schedule}"
+            );
+        }
+
+        #[rstest]
+        #[timeout(Duration::from_secs(1))]
+        fn test_schedule_iter_every_month() {
+            let schedule = Schedule::new("TZ=GMT 13 13 12 * *").unwrap();
+            let mut iter = schedule.iter(&DateTime::parse_from_rfc3339("2024-01-12T13:13:01+00:00").unwrap());
+
+            assert_eq!(
+                iter.next().unwrap().to_rfc3339(),
+                "2024-02-12T13:13:00+00:00",
+                "schedule = {schedule}"
+            );
+            assert_eq!(
+                iter.next().unwrap().to_rfc3339(),
+                "2024-03-12T13:13:00+00:00",
+                "schedule = {schedule}"
+            );
+            assert_eq!(
+                iter.next().unwrap().to_rfc3339(),
+                "2024-04-12T13:13:00+00:00",
+                "schedule = {schedule}"
+            );
+            assert_eq!(
+                iter.next().unwrap().to_rfc3339(),
+                "2024-05-12T13:13:00+00:00",
+                "schedule = {schedule}"
+            );
+            assert_eq!(
+                iter.next().unwrap().to_rfc3339(),
+                "2024-06-12T13:13:00+00:00",
+                "schedule = {schedule}"
+            );
+        }
+
+        #[rstest]
+        #[timeout(Duration::from_secs(1))]
+        fn test_schedule_iter_every_weekday() {
+            let schedule = Schedule::new("TZ=Antarctica/South_Pole 13 13 ? * *").unwrap();
+            let mut iter = schedule.iter(&DateTime::parse_from_rfc3339("2024-01-12T13:13:01+00:00").unwrap());
+
+            assert_eq!(
+                iter.next().unwrap().to_rfc3339(),
+                "2024-01-13T00:13:00+00:00",
+                "schedule = {schedule}"
+            );
+            assert_eq!(
+                iter.next().unwrap().to_rfc3339(),
+                "2024-01-14T00:13:00+00:00",
+                "schedule = {schedule}"
+            );
+            assert_eq!(
+                iter.next().unwrap().to_rfc3339(),
+                "2024-01-15T00:13:00+00:00",
+                "schedule = {schedule}"
+            );
+            assert_eq!(
+                iter.next().unwrap().to_rfc3339(),
+                "2024-01-16T00:13:00+00:00",
+                "schedule = {schedule}"
+            );
+            assert_eq!(
+                iter.next().unwrap().to_rfc3339(),
+                "2024-01-17T00:13:00+00:00",
+                "schedule = {schedule}"
+            );
+        }
+
+        #[rstest]
+        #[timeout(Duration::from_secs(1))]
+        fn test_schedule_iter_every_year() {
+            let schedule = Schedule::new("TZ=Asia/Shanghai 30 12 22 6 ?").unwrap();
+            let mut iter = schedule.iter(&DateTime::parse_from_rfc3339("2021-01-12T13:13:01+00:00").unwrap());
+
+            assert_eq!(
+                iter.next().unwrap().to_rfc3339(),
+                "2021-06-22T04:30:00+00:00",
+                "schedule = {schedule}"
+            );
+            assert_eq!(
+                iter.next().unwrap().to_rfc3339(),
+                "2022-06-22T04:30:00+00:00",
+                "schedule = {schedule}"
+            );
+            assert_eq!(
+                iter.next().unwrap().to_rfc3339(),
+                "2023-06-22T04:30:00+00:00",
+                "schedule = {schedule}"
+            );
+            assert_eq!(
+                iter.next().unwrap().to_rfc3339(),
+                "2024-06-22T04:30:00+00:00",
+                "schedule = {schedule}"
+            );
+            assert_eq!(
+                iter.next().unwrap().to_rfc3339(),
+                "2025-06-22T04:30:00+00:00",
+                "schedule = {schedule}"
+            );
+        }
     }
 }


### PR DESCRIPTION
1. Implement `tz` feature - possibility to specify schedule's timezone in the expression
2. Brarking:
  - remove derive implementations of `PartialOrd` and `Ord` from `Schedule`;
  - add `InvalidTimeZone` error.